### PR TITLE
defer gnuplot check until `NewPlotter` is called

### DIFF
--- a/gnuplot.go
+++ b/gnuplot.go
@@ -14,7 +14,6 @@ import (
 	"os/exec"
 )
 
-var g_gnuplot_cmd string
 var g_gnuplot_prefix string = "go-gnuplot-"
 
 func min(a, b int) int {
@@ -22,16 +21,6 @@ func min(a, b int) int {
 		return a
 	}
 	return b
-}
-
-func init() {
-	var err error
-	g_gnuplot_cmd, err = exec.LookPath("gnuplot")
-	if err != nil {
-		fmt.Printf("** could not find path to 'gnuplot':\n%v\n", err)
-		panic("could not find 'gnuplot'")
-	}
-	fmt.Printf("-- found gnuplot command: %s\n", g_gnuplot_cmd)
 }
 
 type gnuplot_error struct {
@@ -48,12 +37,16 @@ type plotter_process struct {
 }
 
 func new_plotter_proc(persist bool) (*plotter_process, error) {
+	gnuplotCmd, err := exec.LookPath("gnuplot")
+	if err != nil {
+		return nil, fmt.Errorf("could not find gnuplot in PATH: %w", err)
+	}
+
 	proc_args := []string{}
 	if persist {
 		proc_args = append(proc_args, "-persist")
 	}
-	fmt.Printf("--> [%v] %v\n", g_gnuplot_cmd, proc_args)
-	cmd := exec.Command(g_gnuplot_cmd, proc_args...)
+	cmd := exec.Command(gnuplotCmd, proc_args...)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/sbinet/go-gnuplot
+
+go 1.25.5


### PR DESCRIPTION
Thanks for writing this package @sbinet!

## Proposal

Move the gnuplot executable check from init() to new_plotter_proc(). This returns an error instead of panicking when gnuplot is not found.

The previous behavior of checking in init() caused problems because:

1. Any code that imports this package would panic during package initialization, even if it never actually creates a plotter or plots anything. This breaks programs that conditionally use plotting functionality.

2. Running `go test` on a package that imports go-gnuplot would panic even if there are no tests defined, or if the tests don't exercise any plotting code. This makes CI/CD pipelines fail unnecessarily on environments without gnuplot installed.

By deferring the check to when a Plotter is actually created, the package can be safely imported in any environment. The error is returned at the point of use, allowing callers to handle it gracefully.